### PR TITLE
Only append overlay to document when body exists.

### DIFF
--- a/client.js
+++ b/client.js
@@ -86,7 +86,7 @@ problemOverlay.style.top = 0;
 problemOverlay.style.bottom = 0;
 problemOverlay.style.overflow = 'auto';
 
-document.body.appendChild(problemOverlay);
+document.body && document.body.appendChild(problemOverlay);
 
 function showProblems(type, obj) {
   console.warn("[HMR] bundle has " + type + ":");


### PR DESCRIPTION
Hi Glen, thank you for this middleware.

This PR simply checks for existence of body before appending the `problemOverlay` div. This is currently throwing an error in our app that does some custom `document.body` replacement.

Would appreciate a merge + npm publish when you get the chance, cheers.