### PR TITLE
Add header to allow XHR hot-loading

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -47,6 +47,7 @@ function createEventStream(heartbeat) {
     handler: function(req, res) {
       req.socket.setKeepAlive(true);
       res.writeHead(200, {
+        'Access-Control-Allow-Origin': '*',
         'Content-Type': 'text/event-stream;charset=utf-8',
         'Cache-Control': 'no-cache',
         'Connection': 'keep-alive'


### PR DESCRIPTION
Ran into this while trying to load `http://localhost:3000/__webpack_hmr` from another domain.