### PR TITLE
Don't fail update on warnings

### DIFF
--- a/client.js
+++ b/client.js
@@ -84,7 +84,7 @@ function problems(type, obj) {
     console.warn("[HMR] " + clean);
     list.push(clean);
   });
-  if (overlay) overlay.showProblems(list);
+  if (overlay && type !== 'warnings') overlay.showProblems(list);
 }
 
 function success() {

--- a/client.js
+++ b/client.js
@@ -86,6 +86,7 @@ function problems(type, obj) {
   });
   if (overlay) overlay.showProblems(list);
 }
+
 function success() {
   if (overlay) overlay.clear();
 }
@@ -99,10 +100,13 @@ function processMessage(obj) {
     console.log("[HMR] bundle rebuilt in " + obj.time + "ms");
     if (obj.errors.length > 0) {
       problems('errors', obj);
-    } else if (obj.warnings.length > 0) {
-      problems('warnings', obj);
     } else {
-      success();
+      if (obj.warnings.length > 0) {
+        problems('warnings', obj);
+      } else {
+        success();
+      }
+      
       processUpdate(obj.hash, obj.modules, options.reload);
     }
   }


### PR DESCRIPTION
I was banging my head against this issue for a couple of days: my build has a couple of warnings but with the Webpack Dev Server it would update the code just fine, but webpack-hot-middleware wouldn't. Turns out you're not updating the build when there's a warning. This change just brings the webpack-hot-middleware behaviour inline with the server. 

Hopefully it'll save some people from going through my journey again!