### PR TITLE
Handle __webpack_hash__ when it is a function

### DIFF
--- a/processUpdate.js
+++ b/processUpdate.js
@@ -16,7 +16,8 @@ var applyOptions = { ignoreUnaccepted: true };
 
 function upToDate(hash) {
   if (hash) lastHash = hash;
-  return lastHash == __webpack_hash__;
+  var newHash = typeof __webpack_hash__ === 'function' ? __webpack_hash__() : __webpack_hash__;
+  return lastHash == newHash;
 }
 
 module.exports = function(hash, moduleMap, reload) {


### PR DESCRIPTION
My team and I can't use hot reloading until this is fixed per `__webpack_hash__` being a function in the latest webpack versions when in hot mode (https://github.com/chemaxa/webpack/blob/master/main#L520)

If you could merge and publish a patch update this would be greatly helpful! 

Love this middleware. Hot reloading ftw :fist: 