### PR TITLE
Fix client option typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Configuration options can be passed to the client by adding querystring paramete
 * **overlay** - Set to `false` to disable the DOM-based client-side overlay.
 * **reload** - Set to `true` to auto-reload the page when webpack gets stuck.
 * **noInfo** - Set to `true` to disable informational console logging.
-* **reload** - Set to `true` to disable all console logging.
+* **quiet** - Set to `true` to disable all console logging.
 
 ## How it Works
 


### PR DESCRIPTION
Looks like there was a little typo in the documentation for the `quiet` option for the client.