### PR TITLE
Don't skip clearing the screen if build only had warnings

### DIFF
--- a/client.js
+++ b/client.js
@@ -109,11 +109,8 @@ function processMessage(obj) {
     if (obj.errors.length > 0) {
       problems('errors', obj);
     } else {
-      if (obj.warnings.length > 0) {
-        problems('warnings', obj);
-      } else {
-        success();
-      }
+      if (obj.warnings.length > 0) problems('warnings', obj);
+      success();
 
       processUpdate(obj.hash, obj.modules, options);
     }


### PR DESCRIPTION
This is a followup to #15. 

While having warnings (e.g. `console.log`) in the build, the error overlay is not cleared after fixing the broken build.

Doing a full page refresh after every eslint mistake gets annoying quite quickly :)