### PR TITLE
Add comment on using full urls in config

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -4,6 +4,8 @@ module.exports = {
   context: __dirname,
   entry: [
     // Add the client which connects to our middleware
+    // You can use full urls like 'webpack-hot-middleware/client?path=http://localhost:3000/__webpack_hmr'
+    // useful if you run your app from another point like django
     'webpack-hot-middleware/client?path=/__webpack_hmr&timeout=20000',
     // And then the actual application
     './client.js'


### PR DESCRIPTION
I am putting this here as it seems the best place for now.

In hindsight it seems obvious but I did scratch my head to make it work with the component being loaded from a Django application and thus residing on a different port. I could not figure out how to make the calls to hmr tp localhost:8000 go to the nodejs server :)