### PR TITLE
only warn about reload if actually reloading

### DIFF
--- a/process-update.js
+++ b/process-update.js
@@ -99,7 +99,9 @@ module.exports = function(hash, moduleMap, options) {
   }
 
   function performReload() {
-    if (options.warn) console.warn("[HMR] Reloading page");
-    if (reload) window.location.reload();
+    if (reload) {
+      if (options.warn) console.warn("[HMR] Reloading page");
+      window.location.reload();
+    }
   }
 };


### PR DESCRIPTION
The warning misleadingly suggested a reload was happening. Might be even better to warn that a reload is necessary, but not occurring.

NOTE: I winged this in Github web editor without testing, because I'm lazy and optimistic. Think it should work, but caveat emptor.