### PR TITLE
Improve styles

### DIFF
--- a/client-overlay.js
+++ b/client-overlay.js
@@ -4,8 +4,11 @@ var clientOverlay = document.createElement('div');
 clientOverlay.style.display = 'none';
 clientOverlay.style.background = '#fdd';
 clientOverlay.style.color = '#000';
+clientOverlay.style.whiteSpace = 'pre';
+clientOverlay.style.fontFamily = 'monospace';
 clientOverlay.style.position = 'fixed';
 clientOverlay.style.zIndex = 9999;
+clientOverlay.style.padding = '10px';
 clientOverlay.style.left = 0;
 clientOverlay.style.right = 0;
 clientOverlay.style.top = 0;
@@ -21,9 +24,9 @@ function showProblems(lines) {
   clientOverlay.innerHTML = '';
   clientOverlay.style.display = 'block';
   lines.forEach(function(msg) {
-    var pre = document.createElement('pre');
-    pre.textContent = msg;
-    clientOverlay.appendChild(pre);
+    var div = document.createElement('div');
+    div.textContent = msg;
+    clientOverlay.appendChild(div);
   });
 };
 


### PR DESCRIPTION
1. Don’t use `pre` tag because it can be styled by site’s style sheet.
2. Add padding to make it more readable.

For example with Bootstrap it looks like this:

![](http://wow.sapegin.me/image/0l390c292i44/Image%202015-11-30%20at%204.24.04%20PM.png)

And with this pull request like this:

![](http://wow.sapegin.me/image/3n040N2T1F16/Image%202015-11-30%20at%204.25.33%20PM.png)