### PR TITLE
fix console.log in Chrome DevTools

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -5,7 +5,7 @@ var pathMatch = helpers.pathMatch;
 
 function webpackHotMiddleware(compiler, opts) {
   opts = opts || {};
-  opts.log = typeof opts.log == 'undefined' ? console.log : opts.log;
+  opts.log = typeof opts.log == 'undefined' ? console.log.bind(console) : opts.log;
   opts.path = opts.path || '/__webpack_hmr';
   opts.heartbeat = opts.heartbeat || 10 * 1000;
 


### PR DESCRIPTION
I'm debugging a Webpack server in Chrome DevTools (see [devtool](https://github.com/Jam3/devtool)) and logging is broken without this PR, since the context is not correct.