### PR TITLE
fix stats reporting on multicompiler builds

### DIFF
--- a/client.js
+++ b/client.js
@@ -107,7 +107,7 @@ function processMessage(obj) {
   if (obj.action == "building") {
     if (options.log) console.log("[HMR] bundle rebuilding");
   } else if (obj.action == "built") {
-    if (options.log) console.log("[HMR] bundle rebuilt in " + obj.time + "ms");
+    if (options.log) console.log("[HMR] bundle " + (obj.name ? obj.name + " " : "") + "rebuilt in " + obj.time + "ms");
     if (obj.errors.length > 0) {
       problems('errors', obj);
     } else {

--- a/middleware.js
+++ b/middleware.js
@@ -26,6 +26,7 @@ function webpackHotMiddleware(compiler, opts) {
           stats.hash + " in " + stats.time + "ms");
       }
       eventStream.publish({
+        name: stats.name,
         action: "built",
         time: stats.time,
         hash: stats.hash,

--- a/middleware.js
+++ b/middleware.js
@@ -18,10 +18,12 @@ function webpackHotMiddleware(compiler, opts) {
     statsResult = statsResult.toJson();
 
     //for multi-compiler, stats will be an object with a 'children' array of stats
-    var children = statsResult.children ? statsResult.children : [statsResult];
+    var children = statsResult.children && statsResult.children.length ?
+      statsResult.children : [statsResult];
     children.forEach(function(stats) {
       if (opts.log) {
-        opts.log("webpack built " + stats.hash + " in " + stats.time + "ms");
+        opts.log("webpack built " + (stats.name ? stats.name + " " : "") +
+          stats.hash + " in " + stats.time + "ms");
       }
       eventStream.publish({
         action: "built",

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -84,6 +84,40 @@ describe("middleware", function() {
           }
         });
     });
+    it("should notify clients when bundle is complete (multicompiler)", function(done) {
+      request('/__webpack_hmr')
+        .end(function(err, res) {
+          if (err) return done(err);
+
+          res.on('data', verify);
+
+          compiler.emit("done", stats({
+            children: [
+              {
+                time: 100,
+                hash: "deadbeeffeddad",
+                warnings: false,
+                errors: false,
+                modules: []
+              },
+              {
+                time: 150,
+                hash: "gwegawefawefawef",
+                warnings: false,
+                errors: false,
+                modules: []
+              }
+            ]
+          }));
+
+          function verify() {
+            assert.equal(res.events.length, 1);
+            var event = JSON.parse(res.events[0].substring(5));
+            assert.equal(event.action, "built");
+            done();
+          }
+        });
+    });
     it("should have tests on the payload of bundle complete");
     it("should notify all clients", function(done) {
       request('/__webpack_hmr')


### PR DESCRIPTION
Webpack allows "multi-compiler" execution that changes what the stats result looks like.  Instead of a flat object, it adds a children property with an array of stats objects.

https://github.com/webpack/webpack/tree/master/examples/multi-compiler

e.g.
```javascript
{
  children: [
    {time: ...},
    {time: ...},
  ]
}
```