### PR TITLE
Integrate @gaearon's nicer overlay ( #9 )

### DIFF
--- a/client-overlay.js
+++ b/client-overlay.js
@@ -2,8 +2,8 @@
 
 var clientOverlay = document.createElement('div');
 clientOverlay.style.display = 'none';
-clientOverlay.style.background = '#fdd';
-clientOverlay.style.color = '#000';
+clientOverlay.style.background = '#111';
+clientOverlay.style.color = '#fff';
 clientOverlay.style.whiteSpace = 'pre';
 clientOverlay.style.fontFamily = 'monospace';
 clientOverlay.style.position = 'fixed';
@@ -25,7 +25,7 @@ function showProblems(lines) {
   clientOverlay.style.display = 'block';
   lines.forEach(function(msg) {
     var div = document.createElement('div');
-    div.textContent = msg;
+    div.innerHTML = msg;
     clientOverlay.appendChild(div);
   });
 };

--- a/client.js
+++ b/client.js
@@ -79,6 +79,8 @@ function connect(EventSource) {
 }
 
 var strip = require('strip-ansi');
+var Ansi = require('ansi-to-html-umd');
+var ansi = new Ansi();
 
 var overlay;
 if (typeof document !== 'undefined' && options.overlay) {
@@ -89,9 +91,8 @@ function problems(type, obj) {
   if (options.warn) console.warn("[HMR] bundle has " + type + ":");
   var list = [];
   obj[type].forEach(function(msg) {
-    var clean = strip(msg);
-    if (options.warn) console.warn("[HMR] " + clean);
-    list.push(clean);
+    if (options.warn) console.warn("[HMR] " + strip(msg));
+    list.push(ansi.toHtml(msg));
   });
   if (overlay && type !== 'warnings') overlay.showProblems(list);
 }

--- a/client.js
+++ b/client.js
@@ -80,7 +80,9 @@ function connect(EventSource) {
 
 var strip = require('strip-ansi');
 var Ansi = require('ansi-to-html-umd');
-var ansi = new Ansi();
+var ansi = new Ansi({
+  escapeXML: true
+});
 
 var overlay;
 if (typeof document !== 'undefined' && options.overlay) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "strip-ansi": "^3.0.0"
   },
   "devDependencies": {
+    "ansi-to-html-umd": "^0.4.1",
     "express": "^4.13.3",
     "mocha": "^2.3.2",
     "supertest": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "strip-ansi": "^3.0.0"
   },
   "devDependencies": {
-    "ansi-to-html-umd": "^0.4.1",
+    "ansi-to-html-umd": "^0.4.2",
     "express": "^4.13.3",
     "mocha": "^2.3.2",
     "supertest": "^1.1.0",


### PR DESCRIPTION
This PR integrates [Dan's suggestions](https://github.com/glenjamin/webpack-hot-middleware/issues/9#issuecomment-190036073) for a nicer error overlay (#9)

I've forked [rburns/ansi-to-html](https://github.com/rburns/ansi-to-html) as [ansi-to-html-umd](https://github.com/rossipedia/ansi-to-html-umd), and use webpack and webpack/json-loader to build a UMD version, which this pull request uses.