### PR TITLE
Add ability to use custom overlay implementation

### DIFF
--- a/client.js
+++ b/client.js
@@ -125,6 +125,9 @@ if (module) {
   module.exports = {
     subscribe: function subscribe(handler) {
       customHandler = handler;
+    },
+    useCustomOverlay: function useCustomOverlay(customOverlay) {
+      overlay = customOverlay;
     }
   };
 }


### PR DESCRIPTION
Somewhat related to #9 : this method addition allows the user to customize the overlay behavior. This allows implementing the overlay using arbitrary libraries without coupling it with `webpack-hot-middleware`.

Example usage:

``` js
var hotClient = require('webpack-hot-middleware/client')

hotClient.useCustomOverlay({
  showProblems: function (lines) {
    // ...
  },
  clear: function () {
   // ...
  }
})
```

Different overlay implementations can be shipped as npm modules:

``` js
var hotClient = require('webpack-hot-middleware/client')
var myOverlay = require('my-fancy-hot-middleware-overlay')

hotClient.useCustomOverlay(myOverlay)
```