### PR TITLE
Even better overlay styling

### DIFF
--- a/client-overlay.js
+++ b/client-overlay.js
@@ -41,14 +41,18 @@ var colors = {
 };
 ansiHTML.setColors(colors);
 
+var Entities = require('html-entities').AllHtmlEntities;
+var entities = new Entities();
+
 exports.showProblems =
 function showProblems(type, lines) {
   clientOverlay.innerHTML = '';
   clientOverlay.style.display = 'block';
   lines.forEach(function(msg) {
+    msg = ansiHTML(entities.encode(msg));
     var div = document.createElement('div');
     div.style.marginBottom = '2rem';
-    div.innerHTML = problemType(type) + ' in ' + ansiHTML(msg);
+    div.innerHTML = problemType(type) + ' in ' + msg;
     clientOverlay.appendChild(div);
   });
 };

--- a/client-overlay.js
+++ b/client-overlay.js
@@ -20,13 +20,18 @@ if (document.body) {
   document.body.appendChild(clientOverlay);
 }
 
+var Ansi = require('ansi-to-html-umd');
+var ansi = new Ansi({
+  escapeXML: true
+});
+
 exports.showProblems =
 function showProblems(lines) {
   clientOverlay.innerHTML = '';
   clientOverlay.style.display = 'block';
   lines.forEach(function(msg) {
     var div = document.createElement('div');
-    div.innerHTML = msg;
+    div.innerHTML = ansi.toHtml(msg);
     clientOverlay.appendChild(div);
   });
 };

--- a/client-overlay.js
+++ b/client-overlay.js
@@ -1,37 +1,54 @@
 /*eslint-env browser*/
 
 var clientOverlay = document.createElement('div');
-clientOverlay.style.display = 'none';
-clientOverlay.style.background = '#111';
-clientOverlay.style.color = '#fff';
-clientOverlay.style.whiteSpace = 'pre';
-clientOverlay.style.fontFamily = 'monospace';
-clientOverlay.style.fontSize = '16px';
-clientOverlay.style.position = 'fixed';
-clientOverlay.style.zIndex = 9999;
-clientOverlay.style.padding = '10px';
-clientOverlay.style.left = 0;
-clientOverlay.style.right = 0;
-clientOverlay.style.top = 0;
-clientOverlay.style.bottom = 0;
-clientOverlay.style.overflow = 'auto';
+var styles = {
+  display: 'none',
+  background: 'rgba(0,0,0,0.85)',
+  color: '#E8E8E8',
+  lineHeight: '1.2rem',
+  whiteSpace: 'pre',
+  fontFamily: 'Menlo, Consolas, monospace',
+  fontSize: '13px',
+  position: 'fixed',
+  zIndex: 9999,
+  padding: '10px',
+  left: 0,
+  right: 0,
+  top: 0,
+  bottom: 0,
+  overflow: 'auto'
+};
+for (var key in styles) {
+  clientOverlay.style[key] = styles[key];
+}
 
 if (document.body) {
   document.body.appendChild(clientOverlay);
 }
 
-var Ansi = require('ansi-to-html-umd');
-var ansi = new Ansi({
-  escapeXML: true
-});
+var ansiHTML = require('ansi-html');
+var colors = {
+  reset: ['transparent', 'transparent'],
+  black: '181818',
+  red: 'E36049',
+  green: 'B3CB74',
+  yellow: 'FFD080',
+  blue: '7CAFC2',
+  magenta: '7FACCA',
+  cyan: 'C3C2EF',
+  lightgrey: 'EBE7E3',
+  darkgrey: '6D7891'
+};
+ansiHTML.setColors(colors);
 
 exports.showProblems =
-function showProblems(lines) {
+function showProblems(type, lines) {
   clientOverlay.innerHTML = '';
   clientOverlay.style.display = 'block';
   lines.forEach(function(msg) {
     var div = document.createElement('div');
-    div.innerHTML = ansi.toHtml(msg);
+    div.style.marginBottom = '2rem';
+    div.innerHTML = problemType(type) + ' in ' + ansiHTML(msg);
     clientOverlay.appendChild(div);
   });
 };
@@ -42,3 +59,16 @@ function clear() {
   clientOverlay.style.display = 'none';
 };
 
+var problemColors = {
+  errors: colors.red,
+  warnings: colors.yellow
+};
+
+function problemType (type) {
+  var color = problemColors[type] || colors.red;
+  return (
+    '<span style="background-color:#' + color + '; color:#fff; padding:2px 4px; border-radius: 2px">' +
+      type.slice(0, -1).toUpperCase() +
+    '</span>'
+  );
+}

--- a/client.js
+++ b/client.js
@@ -92,7 +92,7 @@ function problems(type, obj) {
       console.warn("[HMR] " + strip(msg));
     });
   }
-  if (overlay && type !== 'warnings') overlay.showProblems(obj[type]);
+  if (overlay && type !== 'warnings') overlay.showProblems(type, obj[type]);
 }
 
 function success() {

--- a/client.js
+++ b/client.js
@@ -79,10 +79,6 @@ function connect(EventSource) {
 }
 
 var strip = require('strip-ansi');
-var Ansi = require('ansi-to-html-umd');
-var ansi = new Ansi({
-  escapeXML: true
-});
 
 var overlay;
 if (typeof document !== 'undefined' && options.overlay) {
@@ -90,13 +86,13 @@ if (typeof document !== 'undefined' && options.overlay) {
 }
 
 function problems(type, obj) {
-  if (options.warn) console.warn("[HMR] bundle has " + type + ":");
-  var list = [];
-  obj[type].forEach(function(msg) {
-    if (options.warn) console.warn("[HMR] " + strip(msg));
-    list.push(ansi.toHtml(msg));
-  });
-  if (overlay && type !== 'warnings') overlay.showProblems(list);
+  if (options.warn) {
+    console.warn("[HMR] bundle has " + type + ":");
+    obj[type].forEach(function(msg) {
+      console.warn("[HMR] " + strip(msg));
+    });
+  }
+  if (overlay && type !== 'warnings') overlay.showProblems(obj[type]);
 }
 
 function success() {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "author": "Glen Mailer <glen@stainlessed.co.uk>",
   "license": "MIT",
   "dependencies": {
+    "ansi-html": "0.0.5",
     "querystring": "^0.2.0",
-    "strip-ansi": "^3.0.0",
-    "ansi-to-html-umd": "^0.4.2"
+    "strip-ansi": "^3.0.0"
   },
   "devDependencies": {
     "express": "^4.13.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "ansi-html": "0.0.5",
+    "html-entities": "^1.2.0",
     "querystring": "^0.2.0",
     "strip-ansi": "^3.0.0"
   },


### PR DESCRIPTION
- Using [ansi-html](https://www.npmjs.com/package/ansi-html) instead of ansi-to-html-umd, which gives us the ability to customize the color output instead of hard-coded colors; (also avoid having to do the umd wrap)

- Adjusted color scheme, fonts, spacing, and added problem type labels. Also added slight opacity to background so that it's more obvious to the user that the current app state is being preserved.

- Moved the ANSI -> HTML conversion logic into `client-overlay.js` instead of `client.js`. This way custom overlay implementations receive raw ANSI strings instead of pre-converted HTML so that they have more flexibility in how to display the messages.

### Before

![screen shot 2016-03-01 at 1 21 13 pm](https://cloud.githubusercontent.com/assets/499550/13437108/884f6000-dfb0-11e5-85e1-027e16c396b6.png)

### After

![screen shot 2016-03-01 at 1 21 01 pm](https://cloud.githubusercontent.com/assets/499550/13437116/8db00d60-dfb0-11e5-852e-5d3bf79b8012.png)
