### PR TITLE
Remvoing REM use from "lineHeight" property

### DIFF
--- a/client-overlay.js
+++ b/client-overlay.js
@@ -5,7 +5,7 @@ var styles = {
   display: 'none',
   background: 'rgba(0,0,0,0.85)',
   color: '#E8E8E8',
-  lineHeight: '1.2rem',
+  lineHeight: '1.2',
   whiteSpace: 'pre',
   fontFamily: 'Menlo, Consolas, monospace',
   fontSize: '13px',

--- a/client-overlay.js
+++ b/client-overlay.js
@@ -51,7 +51,7 @@ function showProblems(type, lines) {
   lines.forEach(function(msg) {
     msg = ansiHTML(entities.encode(msg));
     var div = document.createElement('div');
-    div.style.marginBottom = '2rem';
+    div.style.marginBottom = '26px';
     div.innerHTML = problemType(type) + ' in ' + msg;
     clientOverlay.appendChild(div);
   });


### PR DESCRIPTION
REMs are units relative to a viewport's font size, so if it's set to a small one (like 8px) overlay would have lines jumping over each other