### PR TITLE
Support for webpack 2 module.hot.check promise

### DIFF
--- a/process-update.js
+++ b/process-update.js
@@ -29,7 +29,7 @@ module.exports = function(hash, moduleMap, options) {
   }
 
   function check() {
-    module.hot.check(function(err, updatedModules) {
+    var cb = function(err, updatedModules) {
       if (err) return handleError(err);
 
       if(!updatedModules) {
@@ -48,7 +48,15 @@ module.exports = function(hash, moduleMap, options) {
 
         logUpdates(updatedModules, renewedModules);
       });
-    });
+    };
+    var result = module.hot.check(false, cb);
+    // webpack 2 promise
+    if (result && result.then) {
+        result.then(function(updatedModules) {
+            cb(null, updatedModules);
+        });
+        result.catch(cb);
+    }
   }
 
   function logUpdates(updatedModules, renewedModules) {


### PR DESCRIPTION
Small change that supports both webpack 1's callback and webpack 2's promise for `module.hot.check()`. Fixes #70.