### PR TITLE
Add config for use webpack publicPath as prefix of path

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Configuration options can be passed to the client by adding querystring paramete
 * **reload** - Set to `true` to auto-reload the page when webpack gets stuck.
 * **noInfo** - Set to `true` to disable informational console logging.
 * **quiet** - Set to `true` to disable all console logging.
+* **dynamicPublicPath** - Set to `true` to use webpack `publicPath` as prefix of `path`. (We can set `__webpack_public_path__` dynamically at runtime in the entry point, see note of [output.publicPath](https://webpack.github.io/docs/configuration.html#output-publicpath))
 
 ## How it Works
 

--- a/client.js
+++ b/client.js
@@ -1,5 +1,5 @@
 /*eslint-env browser*/
-/*global __resourceQuery*/
+/*global __resourceQuery __webpack_public_path__*/
 
 var options = {
   path: "/__webpack_hmr",
@@ -22,6 +22,9 @@ if (__resourceQuery) {
   if (overrides.quiet && overrides.quiet !== 'false') {
     options.log = false;
     options.warn = false;
+  }
+  if (overrides.dynamicPublicPath) {
+    options.path = __webpack_public_path__ + options.path;
   }
 }
 


### PR DESCRIPTION
[This is my use case](https://github.com/jhen0409/react-chrome-extension-boilerplate/blob/58702f67a96f1c1b9fecda562e9e39476d162931/webpack/customPublicPath.js), I customize `__webpack_public_path__` in the program (not in webpack config), but this module cannot use it as prefix of `path`.