### PR TITLE
Remove Transfer-Encoding: chunked header from middleware (fixes #114)

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -62,7 +62,6 @@ function createEventStream(heartbeat) {
       res.writeHead(200, {
         'Access-Control-Allow-Origin': '*',
         'Content-Type': 'text/event-stream;charset=utf-8',
-        'Transfer-Encoding': 'chunked',
         'Cache-Control': 'no-cache, no-transform',
         'Connection': 'keep-alive'
       });


### PR DESCRIPTION
Tested with `npm test` and in a local project running HTTP/2 via node-spdy.
Have not tested with vanilla HTTP or HTTPS.