### PR TITLE
Make client overlay direction left-to-right

### DIFF
--- a/client-overlay.js
+++ b/client-overlay.js
@@ -15,7 +15,8 @@ var styles = {
   right: 0,
   top: 0,
   bottom: 0,
-  overflow: 'auto'
+  overflow: 'auto',
+  dir: 'ltr'
 };
 for (var key in styles) {
   clientOverlay.style[key] = styles[key];


### PR DESCRIPTION
This will fixes the issue where the parent element (body or html) have a different direction value like `rtl`. 

