### PR TITLE
added support for koa middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -39,6 +39,11 @@ function webpackHotMiddleware(compiler, opts) {
     if (!pathMatch(req.url, opts.path)) return next();
     eventStream.handler(req, res);
   };
+  var koaMiddleware = function*(next) {
+    if (!pathMatch(this.url, opts.path)) return yield next;
+    eventStream.handler(this.req, this.res);
+  }
+  middleware = !opts.koa ? middleware : koaMiddleware;
   middleware.publish = eventStream.publish;
   return middleware;
 }


### PR DESCRIPTION
Added support for koa applications (generator based `koa v1.2~`). By default, it uses the middleware for Express. If there is the koa flag in the options set to true it will use generator based middleware for koa.
