### PR TITLE
Show error overlay even after browser refresh

### DIFF
--- a/client.js
+++ b/client.js
@@ -123,27 +123,33 @@ var processUpdate = require('./process-update');
 var customHandler;
 var subscribeAllHandler;
 function processMessage(obj) {
-  if (obj.action == "building") {
-    if (options.log) console.log("[HMR] bundle rebuilding");
-  } else if (obj.action == "built") {
-    if (options.log) {
-      console.log(
-        "[HMR] bundle " + (obj.name ? obj.name + " " : "") +
-        "rebuilt in " + obj.time + "ms"
-      );
-    }
-    if (obj.errors.length > 0) {
-      if (reporter) reporter.problems('errors', obj);
-    } else {
-      if (reporter) {
-        if (obj.warnings.length > 0) reporter.problems('warnings', obj);
-        reporter.success();
+  switch(obj.action) {
+    case "building":
+      if (options.log) console.log("[HMR] bundle rebuilding");
+      break;
+    case "built":
+      if (options.log) {
+        console.log(
+          "[HMR] bundle " + (obj.name ? obj.name + " " : "") +
+          "rebuilt in " + obj.time + "ms"
+        );
       }
-
-      processUpdate(obj.hash, obj.modules, options);
-    }
-  } else if (customHandler) {
-    customHandler(obj);
+      // fall through
+    case "sync":
+      if (obj.errors.length > 0) {
+        if (reporter) reporter.problems('errors', obj);
+      } else {
+        if (reporter) {
+          if (obj.warnings.length > 0) reporter.problems('warnings', obj);
+          reporter.success();
+        }
+        processUpdate(obj.hash, obj.modules, options);
+      }
+      break;
+    default:
+      if (customHandler) {
+        customHandler(obj);
+      }
   }
 
   if (subscribeAllHandler) {

--- a/middleware.js
+++ b/middleware.js
@@ -9,7 +9,7 @@ function webpackHotMiddleware(compiler, opts) {
   opts.path = opts.path || '/__webpack_hmr';
   opts.heartbeat = opts.heartbeat || 10 * 1000;
 
-  var eventStream = createEventStream(opts);
+  var eventStream = createEventStream(opts.heartbeat);
   var latestStats = null;
 
   compiler.plugin("compile", function() {
@@ -35,7 +35,7 @@ function webpackHotMiddleware(compiler, opts) {
   return middleware;
 }
 
-function createEventStream(opts) {
+function createEventStream(heartbeat) {
   var clientId = 0;
   var clients = {};
   function everyClient(fn) {
@@ -47,7 +47,7 @@ function createEventStream(opts) {
     everyClient(function(client) {
       client.write("data: \uD83D\uDC93\n\n");
     });
-  }, opts.heartbeat).unref();
+  }, heartbeat).unref();
   return {
     handler: function(req, res) {
       req.socket.setKeepAlive(true);

--- a/middleware.js
+++ b/middleware.js
@@ -13,12 +13,12 @@ function webpackHotMiddleware(compiler, opts) {
   var latestStats = null;
 
   compiler.plugin("compile", function() {
-    // Keep hold of latest stats so they can be propagated to new clients
     latestStats = null;
     if (opts.log) opts.log("webpack building...");
     eventStream.publish({action: "building"});
   });
   compiler.plugin("done", function(statsResult) {
+    // Keep hold of latest stats so they can be propagated to new clients
     latestStats = statsResult;
     publishStats("built", latestStats, eventStream, opts.log);
   });

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -27,17 +27,21 @@ describe("client", function() {
       sinon.assert.calledWithNew(window.EventSource);
       sinon.assert.calledWith(window.EventSource, '/__webpack_hmr');
     });
-    it("should trigger webpack on successful builds", function() {
-      var eventSource = window.EventSource.lastCall.returnValue;
-      eventSource.onmessage(makeMessage({
-        action: 'built',
-        time: 100,
-        hash: 'deadbeeffeddad',
-        errors: [],
-        warnings: [],
-        modules: []
-      }));
-      sinon.assert.calledOnce(processUpdate);
+    it("should trigger webpack on successful builds / syncs", function() {
+      const actions = ['built', 'sync'];
+      actions.forEach(function(action, i) {
+        var eventSource = window.EventSource.lastCall.returnValue;
+        eventSource.onmessage(makeMessage({
+          action: action,
+          time: 100,
+          hash: 'deadbeeffeddad',
+          errors: [],
+          warnings: [],
+          modules: []
+        }));
+        sinon.assert.calledOnce(processUpdate);
+        processUpdate.reset();
+      });
     });
     it("should call subscribeAll handler on default messages", function() {
       var spy = sinon.spy();

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -29,7 +29,7 @@ describe("client", function() {
     });
     it("should trigger webpack on successful builds / syncs", function() {
       const actions = ['built', 'sync'];
-      actions.forEach(function(action, i) {
+      actions.forEach(function(action) {
         var eventSource = window.EventSource.lastCall.returnValue;
         eventSource.onmessage(makeMessage({
           action: action,

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -27,21 +27,29 @@ describe("client", function() {
       sinon.assert.calledWithNew(window.EventSource);
       sinon.assert.calledWith(window.EventSource, '/__webpack_hmr');
     });
-    it("should trigger webpack on successful builds / syncs", function() {
-      const actions = ['built', 'sync'];
-      actions.forEach(function(action) {
-        var eventSource = window.EventSource.lastCall.returnValue;
-        eventSource.onmessage(makeMessage({
-          action: action,
-          time: 100,
-          hash: 'deadbeeffeddad',
-          errors: [],
-          warnings: [],
-          modules: []
-        }));
-        sinon.assert.calledOnce(processUpdate);
-        processUpdate.reset();
-      });
+    it("should trigger webpack on successful builds", function() {
+      var eventSource = window.EventSource.lastCall.returnValue;
+      eventSource.onmessage(makeMessage({
+        action: 'built',
+        time: 100,
+        hash: 'deadbeeffeddad',
+        errors: [],
+        warnings: [],
+        modules: []
+      }));
+      sinon.assert.calledOnce(processUpdate);
+    });
+    it("should trigger webpack on successful syncs", function() {
+      var eventSource = window.EventSource.lastCall.returnValue;
+      eventSource.onmessage(makeMessage({
+        action: 'sync',
+        time: 100,
+        hash: 'deadbeeffeddad',
+        errors: [],
+        warnings: [],
+        modules: []
+      }));
+      sinon.assert.calledOnce(processUpdate);
     });
     it("should call subscribeAll handler on default messages", function() {
       var spy = sinon.spy();

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -118,6 +118,24 @@ describe("middleware", function() {
           }
         });
     });
+    it("should notify new clients about current compilation state", function(done) {
+      compiler.emit("done", stats({
+        time: 100,
+        hash: "deadbeeffeddad",
+        warnings: false,
+        errors: false,
+        modules: []
+      }));
+
+      request('/__webpack_hmr')
+        .end(function(err, res) {
+          if (err) return done(err);
+          assert.equal(res.events.length, 1);
+          var event = JSON.parse(res.events[0].substring(5));
+          assert.equal(event.action, "sync");
+          done();
+        });
+    });
     it("should have tests on the payload of bundle complete");
     it("should notify all clients", function(done) {
       request('/__webpack_hmr')


### PR DESCRIPTION
Currently, if you refresh the client whilst the compilation is in an error state you don't get any feedback (and if using the NoErrorsPlugin you actually get a working app; albeit using the last working bundle) -- you need to check the terminal window to be sure this hasn't happened.

This PR aims to solve the problem by publishing the 'built' event based on the last known compilation stats as soon as a client is registered with the middleware meaning the client script will show the overlay if appropriate.