### PR TITLE
Fix duplicate errors on the client overlay

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -74,7 +74,7 @@ function createEventStream(heartbeat) {
 
 function publishStats(action, statsResult, eventStream, log) {
   // For multi-compiler, stats will be an object with a 'children' array of stats
-  var bundles = extractBundles(statsResult.toJson({  errorDetails: false  }));
+  var bundles = extractBundles(statsResult.toJson({ errorDetails: false }));
   bundles.forEach(function(stats) {
     if (log) {
       log("webpack built " + (stats.name ? stats.name + " " : "") +

--- a/middleware.js
+++ b/middleware.js
@@ -74,7 +74,7 @@ function createEventStream(heartbeat) {
 
 function publishStats(action, statsResult, eventStream, log) {
   // For multi-compiler, stats will be an object with a 'children' array of stats
-  var bundles = extractBundles(statsResult.toJson());
+  var bundles = extractBundles(statsResult.toJson({  errorDetails: false  }));
   bundles.forEach(function(stats) {
     if (log) {
       log("webpack built " + (stats.name ? stats.name + " " : "") +


### PR DESCRIPTION
This will fix the issue: https://github.com/storybooks/react-storybook/issues/543

We do this by using `stats.toJson({ errorDetails: false })` as [mentioned](https://github.com/storybooks/react-storybook/issues/543#issuecomment-258881932) by @SpaceK33z.
I tested this with Storybook and the above issue is gone with this fix.