### PR TITLE
Changes warning color for dark console themes

### DIFF
--- a/client.js
+++ b/client.js
@@ -140,7 +140,7 @@ function createReporter() {
 
   var styles = {
     errors: "color: #ff0000;",
-    warnings: "color: #5c3b00;"
+    warnings: "color: #999933;"
   };
   var previousProblems = null;
   function log(type, obj) {


### PR DESCRIPTION
Warning messages were barely readable in console with a dark theme.
#999933 is a color that is more adaptable to both light and dark consoles.

![image](https://cloud.githubusercontent.com/assets/43061/23446306/20e2ff7e-fe10-11e6-9a3b-ba030e768974.png)

