### PR TITLE
Tell Nginx to proxy event stream messages from webpack-hot-middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -55,7 +55,10 @@ function createEventStream(heartbeat) {
         'Access-Control-Allow-Origin': '*',
         'Content-Type': 'text/event-stream;charset=utf-8',
         'Cache-Control': 'no-cache, no-transform',
-        'Connection': 'keep-alive'
+        'Connection': 'keep-alive',
+        // While behind nginx, event stream should not be buffered:
+        // http://nginx.org/docs/http/ngx_http_proxy_module.html#proxy_buffering
+        'X-Accel-Buffering': 'no'
       });
       res.write('\n');
       var id = clientId++;


### PR DESCRIPTION
When the server with webpack-hot-middleware is behind Nginx proxy, it's not flushing messages immediately.

There are two ways to do so - set up special Nginx rule for this endpoint to proxy it a different way (/__webpack_hmr) or set up a header on server side which is treated as special by Nginx.

Webpack-hot-middleware is only for development purposes. I think that it's worth to add this header for people who i.e. have Docker setup for development machines behind Nginx (what is pretty common I think).