### PR TITLE
Allow easier option configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Configuration options can be passed to the client by adding querystring paramete
 * **noInfo** - Set to `true` to disable informational console logging.
 * **quiet** - Set to `true` to disable all console logging.
 * **dynamicPublicPath** - Set to `true` to use webpack `publicPath` as prefix of `path`. (We can set `__webpack_public_path__` dynamically at runtime in the entry point, see note of [output.publicPath](https://webpack.js.org/configuration/output/#output-publicpath))
+* **autoConnect** - Set to `false` to use to prevent a connection being automatically opened from the client to the webpack back-end - ideal if you need to modify the options using the `setOptionsAndConnect` function
 
 #### Middleware
 

--- a/client.js
+++ b/client.js
@@ -31,6 +31,7 @@ if (typeof window === 'undefined') {
   }
 }
 
+/* istanbul ignore next */
 function setOptions(overrides) {
   setOverrides(overrides);
   connect();

--- a/client.js
+++ b/client.js
@@ -8,11 +8,36 @@ var options = {
   reload: false,
   log: true,
   warn: true,
-  name: ''
+  name: '',
+  autoConnect: true // setting to false will prevent connection from being opened automatically, allowing option manipulation using setOptions
 };
 if (__resourceQuery) {
   var querystring = require('querystring');
   var overrides = querystring.parse(__resourceQuery.slice(1));
+  setOverrides(overrides);
+}
+
+if (typeof window === 'undefined') {
+  // do nothing
+} else if (typeof window.EventSource === 'undefined') {
+  console.warn(
+    "webpack-hot-middleware's client requires EventSource to work. " +
+    "You should include a polyfill if you want to support this browser: " +
+    "https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events#Tools"
+  );
+} else {
+  if (options.autoConnect) {
+    connect();
+  }
+}
+
+function setOptions(overrides) {
+  setOverrides(overrides);
+  connect();
+}
+
+function setOverrides(overrides) {
+  if (overrides.autoConnect) options.autoConnect = overrides.autoConnect == 'true';
   if (overrides.path) options.path = overrides.path;
   if (overrides.timeout) options.timeout = overrides.timeout;
   if (overrides.overlay) options.overlay = overrides.overlay !== 'false';
@@ -27,21 +52,10 @@ if (__resourceQuery) {
     options.log = false;
     options.warn = false;
   }
+
   if (overrides.dynamicPublicPath) {
     options.path = __webpack_public_path__ + options.path;
   }
-}
-
-if (typeof window === 'undefined') {
-  // do nothing
-} else if (typeof window.EventSource === 'undefined') {
-  console.warn(
-    "webpack-hot-middleware's client requires EventSource to work. " +
-    "You should include a polyfill if you want to support this browser: " +
-    "https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events#Tools"
-  );
-} else {
-  connect();
 }
 
 function EventSourceWrapper() {
@@ -249,6 +263,7 @@ if (module) {
     },
     useCustomOverlay: function useCustomOverlay(customOverlay) {
       if (reporter) reporter.useCustomOverlay(customOverlay);
-    }
+    },
+    setOptions
   };
 }

--- a/client.js
+++ b/client.js
@@ -9,7 +9,7 @@ var options = {
   log: true,
   warn: true,
   name: '',
-  autoConnect: true // setting to false will prevent connection from being opened automatically, allowing option manipulation using setOptions
+  autoConnect: true
 };
 if (__resourceQuery) {
   var querystring = require('querystring');
@@ -32,7 +32,7 @@ if (typeof window === 'undefined') {
 }
 
 /* istanbul ignore next */
-function setOptions(overrides) {
+function setOptionsAndConnect(overrides) {
   setOverrides(overrides);
   connect();
 }
@@ -265,6 +265,6 @@ if (module) {
     useCustomOverlay: function useCustomOverlay(customOverlay) {
       if (reporter) reporter.useCustomOverlay(customOverlay);
     },
-    setOptions
+    setOptionsAndConnect
   };
 }


### PR DESCRIPTION
Add function to allow options to be changed without having to use resourceQuery by using the function setOptions.

Unfortunately its not possible to modify the queryString used when importing webpack-hot-middleware with dynamic values, as import statements don't/shouldn't contain any logic.

This change is to allow Next.js to move closer to fully supporting assetPrefixing. The PR using these changes is here: https://github.com/zeit/next.js/pull/2901