### PR TITLE
Use "invalid" event instead of "compile" event

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -12,7 +12,7 @@ function webpackHotMiddleware(compiler, opts) {
   var eventStream = createEventStream(opts.heartbeat);
   var latestStats = null;
 
-  compiler.plugin("compile", function() {
+  compiler.plugin("invalid", function() {
     latestStats = null;
     if (opts.log) opts.log("webpack building...");
     eventStream.publish({action: "building"});

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -51,7 +51,7 @@ describe("middleware", function() {
 
           res.on('data', verify);
 
-          compiler.emit("compile");
+          compiler.emit("invalid");
 
           function verify() {
             assert.equal(res.events.length, 1);
@@ -156,7 +156,7 @@ describe("middleware", function() {
       function when() {
         if (++when.n < 2) return;
 
-        compiler.emit("compile");
+        compiler.emit("invalid");
       }
 
       // Finish test when both requests report data


### PR DESCRIPTION
The "compile" event doesn't fire for a MultiCompiler instance so in my case, the "webpack building..." log never fires. "invalid" seems to work for a single compiler as well as a `MultiCompiler` instance.