### PR TITLE
Custom Client Colors & Styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ Configuration options can be passed to the client by adding querystring paramete
 * **quiet** - Set to `true` to disable all console logging.
 * **dynamicPublicPath** - Set to `true` to use webpack `publicPath` as prefix of `path`. (We can set `__webpack_public_path__` dynamically at runtime in the entry point, see note of [output.publicPath](https://webpack.js.org/configuration/output/#output-publicpath))
 * **autoConnect** - Set to `false` to use to prevent a connection being automatically opened from the client to the webpack back-end - ideal if you need to modify the options using the `setOptionsAndConnect` function
+* **ansiColors** - An object to customize the client overlay colors as mentioned in the [ansi-html](https://github.com/Tjatse/ansi-html/blob/99ec49e431c70af6275b3c4e00c7be34be51753c/README.md#set-colors) package.
+* **overlaySyles** - An object to let you override or add new inline styles to the client overlay div.
+
+> Note:
+> Since the `ansiColors` and `overlaySyles` options are passed via query string, you'll need to uri encode your stringified options like below:
+
+```js
+var ansiColors = {
+  red: '00FF00' // note the lack of "#"
+};
+var overlayStyles = {
+  color: '#FF0000' // note the inclusion of "#" (these options would be the equivalent of div.style[option] = value)
+};
+var hotMiddlewareScript = 'webpack-hot-middleware/client?path=/__webpack_hmr&timeout=20000&reload=true&ansiColors=' + encodeURIComponent(JSON.stringify(ansiColors)) + '&overlayStyles=' + encodeURIComponent(JSON.stringify(overlayStyles));
+```
 
 #### Middleware
 

--- a/client-overlay.js
+++ b/client-overlay.js
@@ -20,9 +20,6 @@ var styles = {
   dir: 'ltr',
   textAlign: 'left'
 };
-for (var key in styles) {
-  clientOverlay.style[key] = styles[key];
-}
 
 var ansiHTML = require('ansi-html');
 var colors = {
@@ -37,12 +34,10 @@ var colors = {
   lightgrey: 'EBE7E3',
   darkgrey: '6D7891'
 };
-ansiHTML.setColors(colors);
 
 var Entities = require('html-entities').AllHtmlEntities;
 var entities = new Entities();
 
-exports.showProblems =
 function showProblems(type, lines) {
   clientOverlay.innerHTML = '';
   lines.forEach(function(msg) {
@@ -55,21 +50,19 @@ function showProblems(type, lines) {
   if (document.body) {
     document.body.appendChild(clientOverlay);
   }
-};
+}
 
-exports.clear =
 function clear() {
   if (document.body && clientOverlay.parentNode) {
     document.body.removeChild(clientOverlay);
   }
-};
-
-var problemColors = {
-  errors: colors.red,
-  warnings: colors.yellow
-};
+}
 
 function problemType (type) {
+  var problemColors = {
+    errors: colors.red,
+    warnings: colors.yellow
+  };
   var color = problemColors[type] || colors.red;
   return (
     '<span style="background-color:#' + color + '; color:#fff; padding:2px 4px; border-radius: 2px">' +
@@ -77,3 +70,28 @@ function problemType (type) {
     '</span>'
   );
 }
+
+module.exports = function(options) {
+  for (var color in options.overlayColors) {
+    if (color in colors) {
+      colors[color] = options.overlayColors[color];
+    }
+    ansiHTML.setColors(colors);
+  }
+
+  for (var style in options.overlayStyles) {
+    styles[style] = options.overlayStyles[style];
+  }
+
+  for (var key in styles) {
+    clientOverlay.style[key] = styles[key];
+  }
+
+  return {
+    showProblems: showProblems,
+    clear: clear
+  }
+};
+
+module.exports.clear = clear;
+module.exports.showProblems = showProblems;

--- a/client.js
+++ b/client.js
@@ -9,7 +9,9 @@ var options = {
   log: true,
   warn: true,
   name: '',
-  autoConnect: true
+  autoConnect: true,
+  overlayStyles: {},
+  ansiColors: {}
 };
 if (__resourceQuery) {
   var querystring = require('querystring');
@@ -57,6 +59,9 @@ function setOverrides(overrides) {
   if (overrides.dynamicPublicPath) {
     options.path = __webpack_public_path__ + options.path;
   }
+
+  if (overrides.ansiColors) options.ansiColors = JSON.parse(overrides.ansiColors);
+  if (overrides.overlayStyles) options.overlayStyles = JSON.parse(overrides.overlayStyles);
 }
 
 function EventSourceWrapper() {
@@ -150,7 +155,10 @@ function createReporter() {
 
   var overlay;
   if (typeof document !== 'undefined' && options.overlay) {
-    overlay = require('./client-overlay');
+    overlay = require('./client-overlay')({
+      ansiColors: options.ansiColors,
+      overlayStyles: options.overlayStyles
+    });
   }
 
   var styles = {

--- a/example/index.html
+++ b/example/index.html
@@ -13,6 +13,6 @@
         placeholder="Type something in here to prove state isn't lost"
     />
 </div>
-<script src="/bundle.js"></script>
+<script src="/client.js"></script>
 </body>
 </html>

--- a/example/webpack.config.multientry.js
+++ b/example/webpack.config.multientry.js
@@ -18,6 +18,6 @@ module.exports = {
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.NoEmitOnErrorsPlugin()
   ],
 };


### PR DESCRIPTION
Addresses #262 minus the [parser comment](https://github.com/glenjamin/webpack-hot-middleware/issues/262#issuecomment-344595300). Not sure how to easily get that stack trace to show up in the example. Seems like you'd need a more complex setup than that of the example folder.

In addition to allowing for customization of the ansi colors via `ansiColors`, this also lets you customize the inline styles of the overlay div via `overlayStyles`.

Other related tickets #256 #261 