### PR TITLE
Feature/overlay warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Configuration options can be passed to the client by adding querystring paramete
 * **autoConnect** - Set to `false` to use to prevent a connection being automatically opened from the client to the webpack back-end - ideal if you need to modify the options using the `setOptionsAndConnect` function
 * **ansiColors** - An object to customize the client overlay colors as mentioned in the [ansi-html](https://github.com/Tjatse/ansi-html/blob/99ec49e431c70af6275b3c4e00c7be34be51753c/README.md#set-colors) package.
 * **overlaySyles** - An object to let you override or add new inline styles to the client overlay div.
+* **overlayWarnings** - Set to `true` to enable client overlay on warnings in addition to errors.
 
 > Note:
 > Since the `ansiColors` and `overlaySyles` options are passed via query string, you'll need to uri encode your stringified options like below:

--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ Configuration options can be passed to the client by adding querystring paramete
 * **dynamicPublicPath** - Set to `true` to use webpack `publicPath` as prefix of `path`. (We can set `__webpack_public_path__` dynamically at runtime in the entry point, see note of [output.publicPath](https://webpack.js.org/configuration/output/#output-publicpath))
 * **autoConnect** - Set to `false` to use to prevent a connection being automatically opened from the client to the webpack back-end - ideal if you need to modify the options using the `setOptionsAndConnect` function
 * **ansiColors** - An object to customize the client overlay colors as mentioned in the [ansi-html](https://github.com/Tjatse/ansi-html/blob/99ec49e431c70af6275b3c4e00c7be34be51753c/README.md#set-colors) package.
-* **overlaySyles** - An object to let you override or add new inline styles to the client overlay div.
+* **overlayStyles** - An object to let you override or add new inline styles to the client overlay div.
 * **overlayWarnings** - Set to `true` to enable client overlay on warnings in addition to errors.
 
 > Note:
-> Since the `ansiColors` and `overlaySyles` options are passed via query string, you'll need to uri encode your stringified options like below:
+> Since the `ansiColors` and `overlayStyles` options are passed via query string, you'll need to uri encode your stringified options like below:
 
 ```js
 var ansiColors = {

--- a/client.js
+++ b/client.js
@@ -11,6 +11,7 @@ var options = {
   name: '',
   autoConnect: true,
   overlayStyles: {},
+  overlayWarnings: false,
   ansiColors: {}
 };
 if (__resourceQuery) {
@@ -62,6 +63,7 @@ function setOverrides(overrides) {
 
   if (overrides.ansiColors) options.ansiColors = JSON.parse(overrides.ansiColors);
   if (overrides.overlayStyles) options.overlayStyles = JSON.parse(overrides.overlayStyles);
+  if (overrides.overlayWarnings) options.overlayWarnings = JSON.parse(overrides.overlayWarnings);
 }
 
 function EventSourceWrapper() {
@@ -200,7 +202,9 @@ function createReporter() {
       if (options.warn) {
         log(type, obj);
       }
-      if (overlay && type !== 'warnings') overlay.showProblems(type, obj[type]);
+      if (overlay && (options.overlayWarnings || type !== 'warnings')) {
+        overlay.showProblems(type, obj[type]);
+      }
     },
     success: function() {
       if (overlay) overlay.clear();
@@ -239,15 +243,11 @@ function processMessage(obj) {
       }
       if (obj.errors.length > 0) {
         if (reporter) reporter.problems('errors', obj);
+      } else if (obj.warnings.length > 0) {
+        if (reporter) reporter.problems('warnings', obj);
       } else {
-        if (reporter) {
-          if (obj.warnings.length > 0) {
-            reporter.problems('warnings', obj);
-          } else {
-            reporter.cleanProblemsCache();
-          }
-          reporter.success();
-        }
+        reporter.cleanProblemsCache();
+        reporter.success();
         processUpdate(obj.hash, obj.modules, options);
       }
       break;

--- a/client.js
+++ b/client.js
@@ -63,7 +63,10 @@ function setOverrides(overrides) {
 
   if (overrides.ansiColors) options.ansiColors = JSON.parse(overrides.ansiColors);
   if (overrides.overlayStyles) options.overlayStyles = JSON.parse(overrides.overlayStyles);
-  if (overrides.overlayWarnings) options.overlayWarnings = JSON.parse(overrides.overlayWarnings);
+
+  if (overrides.overlayWarnings) {
+    options.overlayWarnings = overrides.overlayWarnings == 'true';
+  }
 }
 
 function EventSourceWrapper() {

--- a/client.js
+++ b/client.js
@@ -249,8 +249,10 @@ function processMessage(obj) {
       } else if (obj.warnings.length > 0) {
         if (reporter) reporter.problems('warnings', obj);
       } else {
-        reporter.cleanProblemsCache();
-        reporter.success();
+        if (reporter) {
+          reporter.cleanProblemsCache();
+          reporter.success();
+        }
         processUpdate(obj.hash, obj.modules, options);
       }
       break;


### PR DESCRIPTION
Not 100% on the [revised conditional logic](https://github.com/benjarwar/webpack-hot-middleware/blob/8d54ae828a2417ded3a79d5b7902f704edb877e4/client.js#L246-L252), but tested everything locally and it behaves as expected. The overlay will display on warnings only if `overlayWarnings` option is set to `true`. Warnings always still display in the console.