### PR TITLE
fixed call to bundle file in example

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -13,6 +13,6 @@
         placeholder="Type something in here to prove state isn't lost"
     />
 </div>
-<script src="/client.js"></script>
+<script src="/bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
I'd been trying to get HMR working with the package and decided to clone the repo so I can see how the example works. Kept getting 404's when it was calling client.js. Looked into the webpack config and noticed it was creating a file called bundle.js. 