### PR TITLE
Replace 'compile' with 'invalid' hook.

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -13,13 +13,13 @@ function webpackHotMiddleware(compiler, opts) {
   var latestStats = null;
 
   if (compiler.hooks) {
-    compiler.hooks.compile.tap("webpack-hot-middleware", onCompile);
+    compiler.hooks.invalid.tap("webpack-hot-middleware", onInvalid);
     compiler.hooks.done.tap("webpack-hot-middleware", onDone);
   } else {
-    compiler.plugin("compile", onCompile);
+    compiler.plugin("invalid", onInvalid);
     compiler.plugin("done", onDone);
   }
-  function onCompile() {
+  function onInvalid() {
     latestStats = null;
     if (opts.log) opts.log("webpack building...");
     eventStream.publish({action: "building"});

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -51,7 +51,7 @@ describe("middleware", function() {
 
           res.on('data', verify);
 
-          compiler.emit("compile");
+          compiler.emit("invalid");
 
           function verify() {
             assert.equal(res.events.length, 1);
@@ -156,7 +156,7 @@ describe("middleware", function() {
       function when() {
         if (++when.n < 2) return;
 
-        compiler.emit("compile");
+        compiler.emit("invalid");
       }
 
       // Finish test when both requests report data


### PR DESCRIPTION
Following https://github.com/glenjamin/webpack-hot-middleware/pull/260.

As suggested https://github.com/webpack/webpack/issues/6633#issuecomment-369715848, we rather iterate each compiler and register the 'compile' hook when getting a MultiCompiler instance than register the 'invalid' hook.