### PR TITLE
Publish correct action for built modules in multi-compiler (built/sync)

### DIFF
--- a/client.js
+++ b/client.js
@@ -264,7 +264,7 @@ function processMessage(obj) {
           reporter.success();
         }
       }
-      if (applyUpdate) {
+      if (applyUpdate && obj.action === "built") {
         processUpdate(obj.hash, obj.modules, options);
       }
       break;

--- a/middleware.js
+++ b/middleware.js
@@ -10,7 +10,8 @@ function webpackHotMiddleware(compiler, opts) {
   opts.heartbeat = opts.heartbeat || 10 * 1000;
 
   var eventStream = createEventStream(opts.heartbeat);
-  var latestStats = null;
+  var latestBundles = null;
+  var isValid = false;
 
   if (compiler.hooks) {
     compiler.hooks.invalid.tap("webpack-hot-middleware", onInvalid);
@@ -20,22 +21,24 @@ function webpackHotMiddleware(compiler, opts) {
     compiler.plugin("done", onDone);
   }
   function onInvalid() {
-    latestStats = null;
+    isValid = false;
     if (opts.log) opts.log("webpack building...");
     eventStream.publish({action: "building"});
   }
   function onDone(statsResult) {
     // Keep hold of latest stats so they can be propagated to new clients
-    latestStats = statsResult;
-    publishStats("built", latestStats, eventStream, opts.log);
+    var bundles = extractBundles(statsResult.toJson({ errorDetails: false }));
+    isValid = true;
+    publishStats(latestBundles, bundles, eventStream, opts.log);
+    latestBundles = bundles;
   }
   var middleware = function(req, res, next) {
     if (!pathMatch(req.url, opts.path)) return next();
     eventStream.handler(req, res);
-    if (latestStats) {
+    if (latestBundles && isValid) {
       // Explicitly not passing in `log` fn as we don't want to log again on
       // the server
-      publishStats("sync", latestStats, eventStream);
+      publishStats(latestBundles, latestBundles, eventStream);
     }
   };
   middleware.publish = eventStream.publish;
@@ -82,14 +85,14 @@ function createEventStream(heartbeat) {
   };
 }
 
-function publishStats(action, statsResult, eventStream, log) {
+function publishStats(latestBundles, bundles, eventStream, log) {
   // For multi-compiler, stats will be an object with a 'children' array of stats
-  var bundles = extractBundles(statsResult.toJson({ errorDetails: false }));
-  bundles.forEach(function(stats) {
+  bundles.forEach(function(stats, idx) {
     if (log) {
       log("webpack built " + (stats.name ? stats.name + " " : "") +
         stats.hash + " in " + stats.time + "ms");
     }
+    var action = (!latestBundles || latestBundles[idx].hash === stats.hash) ? "sync" : "built";
     eventStream.publish({
       name: stats.name,
       action: action,


### PR DESCRIPTION
In the client side, when receiving the "built" action, it tries to load a manifest for the updated chunks, but such manifest is only available when the bundle actually has changed (is not available the first time either, for example), so the result is an error message in the client saying it's getting a 404 for such manifest. Changes where made so it only tries to load such manifest when "built" action is received, but not "sync".

In the server side, this pull request makes it so in multi-compiler each bundle is sent with proper action. Not all bundles change when one does, so not all should send "built" action, which would try to load a manifest that might not be there.

Fixes issue #270