### PR TITLE
Fix possible double slashs when dynamicPublicPath

### DIFF
--- a/client.js
+++ b/client.js
@@ -59,7 +59,7 @@ function setOverrides(overrides) {
   }
 
   if (overrides.dynamicPublicPath) {
-    options.path = __webpack_public_path__ + options.path;
+    options.path = (__webpack_public_path__ + options.path).replace(/\/\//g, '/');
   }
 
   if (overrides.ansiColors)


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Hi,
Thanks for this package!

I'm in a situation where a tool I can't control set my publicPath from config, and add a `/` to it. In fact webpack [recommends to do that](https://webpack.js.org/configuration/output/#outputpublicpath):

>The value of the option is prefixed to every URL created by the runtime or loaders. Because of this the value of this option ends with / in most cases.

However the HMR path also starts with a `/`, and all the default paths and example of this package!

With theses both slashes, when in case of `dynamicPublicPath: true`, we end to a `publicPath//path` path.

This little PR just fixes that by replacing all `//` with `/` in the paths concatenation.

Thanks,
Mathieu.
