### PR TITLE
chore: Correct stats generation in webpack 5

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -226,7 +226,7 @@ function extractBundles(stats) {
 function buildModuleMap(modules) {
   var map = {};
   modules.forEach(function (module) {
-    map[module.id] = module.name;
+    map[module.id || module.index || module.identifier] = module.name;
   });
   return map;
 }


### PR DESCRIPTION
This PR contains a:

- [X] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The stats generation via `buildModuleMap` uses `module.id` which doesn't exist in webpack 5 returning just the last module (as the key of the map is always `undefined`)

### Breaking Changes

NONE: Still prioritizing module.id, if it is not defined fallback the value to index or identifier

### Additional Info
