### PR TITLE
Introduce `overlayStyleMode` option to manage overlay styling behavior

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ workflows:
             tags:
               only: /.*/
 
-
 commands:
   setup:
     steps:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Configuration options can be passed to the client by adding querystring paramete
 * **dynamicPublicPath** - Set to `true` to use webpack `publicPath` as prefix of `path`. (We can set `__webpack_public_path__` dynamically at runtime in the entry point, see note of [output.publicPath](https://webpack.js.org/configuration/output/#output-publicpath))
 * **autoConnect** - Set to `false` to use to prevent a connection being automatically opened from the client to the webpack back-end - ideal if you need to modify the options using the `setOptionsAndConnect` function
 * **ansiColors** - An object to customize the client overlay colors as mentioned in the [ansi-html-community](https://github.com/mahdyar/ansi-html-community#set-colors) package.
-* **overlayStyles** - An object to let you override or add new inline styles to the client overlay div.
+* **overlayStyleMode** - Set to `'inline'` to use inline styling (default), or `'headless'` for custom or [CSP](https://webpack.js.org/guides/csp/) compatible styling (You can import `webpack-hot-middleware/client-overlay.css` to enable the default styles; make sure a proper loader have been configured for the CSS files).
+* **overlayStyles** - An object to let you override or add new inline styles to the client overlay div. Requires `overlayStyleMode` to be `'inline'`.
 * **overlayWarnings** - Set to `true` to enable client overlay on warnings in addition to errors.
 * **statsOptions** - An object to customize stats options.
 

--- a/client-overlay.css
+++ b/client-overlay.css
@@ -1,0 +1,36 @@
+.webpack-hot-middleware-clientOverlay {
+  background: rgba(0, 0, 0, 0.85);
+  color: #e8e8e8;
+  line-height: 1.6;
+  white-space: pre;
+  font-family: Menlo, Consolas, monospace;
+  font-size: 13px;
+  position: fixed;
+  z-index: 9999;
+  padding: 10px;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  overflow: auto;
+  dir: ltr;
+  text-align: left;
+}
+
+.webpack-hot-middleware-clientOverlay__problem-group {
+  margin-bottom: 26px;
+}
+
+.webpack-hot-middleware-clientOverlay__problem {
+  color: #000000;
+  padding: 3px 6px;
+  border-radius: 4px;
+}
+
+.webpack-hot-middleware-clientOverlay__problem--error {
+  background-color: #ff3348;
+}
+
+.webpack-hot-middleware-clientOverlay__problem--warning {
+  background-color: #ffd30e;
+}

--- a/client-overlay.js
+++ b/client-overlay.js
@@ -2,6 +2,8 @@
 
 var clientOverlay = document.createElement('div');
 clientOverlay.id = 'webpack-hot-middleware-clientOverlay';
+clientOverlay.classList.add('webpack-hot-middleware-clientOverlay');
+
 var styles = {
   background: 'rgba(0,0,0,0.85)',
   color: '#e8e8e8',
@@ -37,13 +39,16 @@ var colors = {
 
 var htmlEntities = require('html-entities');
 
-function showProblems(type, lines) {
+function showProblems(type, lines, options) {
   clientOverlay.innerHTML = '';
   lines.forEach(function (msg) {
     msg = ansiHTML(htmlEntities.encode(msg));
     var div = document.createElement('div');
-    div.style.marginBottom = '26px';
-    div.innerHTML = problemType(type) + ' in ' + msg;
+    div.classList.add('webpack-hot-middleware-clientOverlay__problem-group');
+    if (options.overlayStyleMode === 'inline') {
+      div.style.marginBottom = '26px';
+    }
+    div.innerHTML = problemType(type, options) + ' in ' + msg;
     clientOverlay.appendChild(div);
   });
   if (document.body) {
@@ -57,17 +62,32 @@ function clear() {
   }
 }
 
-function problemType(type) {
+function problemType(type, options) {
+  var problemTypeSingularNames = {
+    errors: 'error',
+    warnings: 'warning',
+  };
+  var typeName = problemTypeSingularNames[type] || 'error';
+  var className = 'webpack-hot-middleware-clientOverlay__problem--' + typeName;
   var problemColors = {
     errors: colors.red,
     warnings: colors.yellow,
   };
-  var color = problemColors[type] || colors.red;
+  var styleAttributeFragment = '';
+  if (options.overlayStyleMode === 'inline') {
+    var color = problemColors[type] || colors.red;
+    styleAttributeFragment =
+      ' style="background-color:#' +
+      color +
+      '; color:#000000; padding:3px 6px; border-radius: 4px;"';
+  }
   return (
-    '<span style="background-color:#' +
-    color +
-    '; color:#000000; padding:3px 6px; border-radius: 4px;">' +
-    type.slice(0, -1).toUpperCase() +
+    '<span class="webpack-hot-middleware-clientOverlay__problem ' +
+    className +
+    '"' +
+    styleAttributeFragment +
+    '>' +
+    typeName.toUpperCase() +
     '</span>'
   );
 }
@@ -80,12 +100,14 @@ module.exports = function (options) {
     ansiHTML.setColors(colors);
   }
 
-  for (var style in options.overlayStyles) {
-    styles[style] = options.overlayStyles[style];
-  }
+  if (options.overlayStyleMode === 'inline') {
+    for (var style in options.overlayStyles) {
+      styles[style] = options.overlayStyles[style];
+    }
 
-  for (var key in styles) {
-    clientOverlay.style[key] = styles[key];
+    for (var key in styles) {
+      clientOverlay.style[key] = styles[key];
+    }
   }
 
   return {

--- a/client.js
+++ b/client.js
@@ -13,6 +13,7 @@ var options = {
   overlayStyles: {},
   overlayWarnings: false,
   ansiColors: {},
+  overlayStyleMode: 'inline', // 'headless', 'inline'
 };
 if (__resourceQuery) {
   var params = Array.from(new URLSearchParams(__resourceQuery.slice(1)));
@@ -73,6 +74,21 @@ function setOverrides(overrides) {
 
   if (overrides.overlayWarnings) {
     options.overlayWarnings = overrides.overlayWarnings == 'true';
+  }
+  if (overrides.overlayStyleMode) {
+    if (
+      overrides.overlayStyleMode === 'inline' ||
+      overrides.overlayStyleMode === 'headless'
+    ) {
+      options.overlayStyleMode = overrides.overlayStyleMode;
+    } else {
+      console.warn(
+        'Unsupported `overlayStyleMode` value. Expected one of `inline`, or `headless`.' +
+          'Falling back to the default mode: `' +
+          options.overlayStyleMode +
+          '`.'
+      );
+    }
   }
 }
 
@@ -167,10 +183,7 @@ function createReporter() {
 
   var overlay;
   if (typeof document !== 'undefined' && options.overlay) {
-    overlay = require('./client-overlay')({
-      ansiColors: options.ansiColors,
-      overlayStyles: options.overlayStyles,
-    });
+    overlay = require('./client-overlay')(options);
   }
 
   var styles = {
@@ -218,7 +231,7 @@ function createReporter() {
       }
       if (overlay) {
         if (options.overlayWarnings || type === 'errors') {
-          overlay.showProblems(type, obj[type]);
+          overlay.showProblems(type, obj[type], options);
           return false;
         }
         overlay.clear();

--- a/example/README.md
+++ b/example/README.md
@@ -7,10 +7,15 @@
 ```sh
 npm install
 ```
-* Start server
+
+## Basic Hot Reload Example
+
+Start server:
+
 ```sh
 npm start
 ```
+
 * Open page in browser http://localhost:1616
 * Open the developer console
 * Edit `client.js` & save
@@ -27,3 +32,43 @@ npm run start:multientry
 
 * Open page in browser http://localhost:1616/multientry
 * Edit `client.js` or `extra.js` & save
+
+## CSP-compatible Styling Examples
+
+These scenarios run with a strict CSP configuration that disallow inline styles.
+
+### CSP Violation
+
+This scenario intentionally violates CSP rules by inlining the styles instead of importing from a CSS file.
+
+```sh
+npm run start:csp::violate
+```
+
+* Open the page in browser http://localhost:1616/csp
+* Try making a syntax error in `client.js`.
+* Check the console logs; CSP must be violated, styles must be blocked.
+
+### CSP-compatible Styling
+
+Since inline styles are disallowed, styles must be imported from a CSS file. To demonstrate this, the example uses `file-loader` and `style-loader` by setting the `injectType` option to `linkTag`.
+
+```sh
+npm run start:csp
+```
+
+* Open the page in browser http://localhost:1616/csp
+* Try making a syntax error in `client.js`.
+* Check the console logs; CSP must not be violated, styles must be applied.
+
+## Headless Styling Example
+
+This scenario demonstrates custom styling behavior.
+
+```sh
+npm run start:headless-styling
+```
+
+* Open the page in browser http://localhost:1616/headless-styling
+* Try making a syntax error in `client.js`.
+* The `ERROR` label must appear as white text on a black background only.

--- a/example/client.js
+++ b/example/client.js
@@ -4,19 +4,25 @@ var time = document.getElementById('time');
 
 var timer = setInterval(updateClock, 1000);
 
+var isInlineStylingAllowed =
+  app.dataset.overlayStyleMode == null ||
+  app.dataset.overlayStyleMode === 'inline';
+
 function updateClock() {
   time.innerHTML = new Date().toString();
 }
 
-// Edit these styles to see them take effect immediately
-app.style.display = 'table-cell';
-app.style.width = '400px';
-app.style.height = '400px';
-app.style.border = '3px solid #339';
-app.style.background = '#99d';
-app.style.color = '#333';
-app.style.textAlign = 'center';
-app.style.verticalAlign = 'middle';
+if (isInlineStylingAllowed) {
+  // Edit these styles to see them take effect immediately
+  app.style.display = 'table-cell';
+  app.style.width = '400px';
+  app.style.height = '400px';
+  app.style.border = '3px solid #339';
+  app.style.background = '#99d';
+  app.style.color = '#333';
+  app.style.textAlign = 'center';
+  app.style.verticalAlign = 'middle';
+}
 
 // Uncomment one of the following lines to see error handling
 // require('unknown-module')

--- a/example/csp.js
+++ b/example/csp.js
@@ -1,0 +1,5 @@
+console.log('Testing CSP...');
+
+if (module.hot) {
+  module.hot.accept();
+}

--- a/example/headless-styling.js
+++ b/example/headless-styling.js
@@ -1,0 +1,5 @@
+console.log('Testing headless styling...');
+
+if (module.hot) {
+  module.hot.accept();
+}

--- a/example/index-csp.html
+++ b/example/index-csp.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Webpack Hot Middleware CSP Example</title>
+  </head>
+  <body>
+    <div id="app" data-overlay-style-mode="headless">
+      <p id="time">Date</p>
+      <input
+        type="text"
+        size="40"
+        placeholder="Type something in here to prove state isn't lost"
+      />
+    </div>
+    <script src="/client.js"></script>
+    <script src="/csp.js"></script>
+  </body>
+</html>

--- a/example/index-headless-styling.html
+++ b/example/index-headless-styling.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Webpack Hot Middleware Headless Styling Example</title>
+    <style>
+      .webpack-hot-middleware-clientOverlay__problem-group {
+        margin-bottom: 26px;
+      }
+
+      .webpack-hot-middleware-clientOverlay__problem {
+        color: #ffffff;
+        padding: 3px 6px;
+        border-radius: 4px;
+      }
+
+      .webpack-hot-middleware-clientOverlay__problem--error {
+        background-color: #000000;
+      }
+
+      .webpack-hot-middleware-clientOverlay__problem--warning {
+        background-color: #000000;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app" data-overlay-style-mode="headless">
+      <p id="time">Date</p>
+      <input
+        type="text"
+        size="40"
+        placeholder="Type something in here to prove state isn't lost"
+      />
+    </div>
+    <script src="/client.js"></script>
+    <script src="/headless-styling.js"></script>
+  </body>
+</html>

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -11,14 +11,15 @@
       "dependencies": {
         "console-stamp": "^0.2.9",
         "express": "^4.17.1",
+        "file-loader": "^6.2.0",
         "morgan": "^1.10.0",
+        "style-loader": "^4.0.0",
         "webpack": "^5.74.0",
         "webpack-dev-middleware": "^5.3.3",
         "webpack-hot-middleware": "file:.."
       }
     },
     "..": {
-      "name": "webpack-hot-middleware",
       "version": "2.26.1",
       "license": "MIT",
       "dependencies": {
@@ -477,6 +478,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
@@ -785,6 +795,15 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
     },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -944,6 +963,26 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "node_modules/file-loader": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
     },
     "node_modules/finalhandler": {
       "version": "1.2.0",
@@ -1221,6 +1260,18 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -1240,6 +1291,20 @@
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "engines": {
         "node": ">=6.11.5"
+      }
+    },
+    "node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
       }
     },
     "node_modules/locate-path": {
@@ -1545,9 +1610,10 @@
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1949,6 +2015,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+      "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.27.0"
       }
     },
     "node_modules/supports-color": {
@@ -2668,6 +2750,11 @@
         }
       }
     },
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+    },
     "body-parser": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
@@ -2880,6 +2967,11 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
     },
+    "emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -3008,6 +3100,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "file-loader": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      }
     },
     "finalhandler": {
       "version": "1.2.0",
@@ -3209,6 +3310,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -3223,6 +3329,16 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="
+    },
+    "loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      }
     },
     "locate-path": {
       "version": "7.1.1",
@@ -3436,9 +3552,9 @@
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
     "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -3728,6 +3844,12 @@
       "requires": {
         "min-indent": "^1.0.1"
       }
+    },
+    "style-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+      "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
+      "requires": {}
     },
     "supports-color": {
       "version": "2.0.0",

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,9 @@
   "dependencies": {
     "console-stamp": "^0.2.9",
     "express": "^4.17.1",
+    "file-loader": "^6.2.0",
     "morgan": "^1.10.0",
+    "style-loader": "^4.0.0",
     "webpack": "^5.74.0",
     "webpack-dev-middleware": "^5.3.3",
     "webpack-hot-middleware": "file:.."

--- a/example/package.json
+++ b/example/package.json
@@ -16,6 +16,9 @@
   },
   "scripts": {
     "start:base": "WEBPACK_CONFIG=./webpack.config.js node server.js",
+    "start:csp": "WEBPACK_CONFIG=./webpack.config.csp.js node server.js",
+    "start:csp::violate": "WEBPACK_HOT_MIDDLEWARE_VIOLATE_CSP=true npm run start:csp",
+    "start:headless-styling": "WEBPACK_CONFIG=./webpack.config.headless-styling.js node server.js",
     "start:multientry": "WEBPACK_CONFIG=./webpack.config.multientry.js node server.js"
   }
 }

--- a/example/server.js
+++ b/example/server.js
@@ -44,10 +44,17 @@ app.get('/', function (req, res) {
 app.get('/multientry', function (req, res) {
   res.sendFile(__dirname + '/index-multientry.html');
 });
+app.get('/csp', function (req, res) {
+  res.set('Content-Security-Policy', "style-src 'self';");
+  res.sendFile(__dirname + '/index-csp.html');
+});
+app.get('/headless-styling', function (req, res) {
+  res.sendFile(__dirname + '/index-headless-styling.html');
+});
 
 if (require.main === module) {
   var server = http.createServer(app);
-  server.listen(process.env.PORT || 1616, "localhost", function () {
+  server.listen(process.env.PORT || 1616, 'localhost', function () {
     console.log('Listening on %j', server.address());
   });
 }

--- a/example/webpack.config.csp.js
+++ b/example/webpack.config.csp.js
@@ -1,0 +1,46 @@
+var webpack = require('webpack');
+var violateCSP = process.env.WEBPACK_HOT_MIDDLEWARE_VIOLATE_CSP == 'true';
+var hotMiddlewareScript =
+  'webpack-hot-middleware/client?path=/__webpack_hmr&timeout=20000&reload=true' +
+  '&overlayStyleMode=' +
+  (violateCSP ? 'inline' : 'headless');
+
+module.exports = {
+  mode: 'development',
+  context: __dirname,
+  entry: {
+    client: [
+      './client.js',
+      hotMiddlewareScript,
+      'webpack-hot-middleware/client-overlay.css',
+    ],
+    csp: [
+      './csp.js',
+      hotMiddlewareScript,
+      'webpack-hot-middleware/client-overlay.css',
+    ],
+  },
+  output: {
+    path: __dirname,
+    publicPath: '/',
+    filename: '[name].js',
+  },
+  devtool: 'source-map',
+  plugins: [new webpack.HotModuleReplacementPlugin()],
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: [
+          {
+            loader: require.resolve('style-loader'),
+            options: {
+              injectType: 'linkTag',
+            },
+          },
+          { loader: require.resolve('file-loader') },
+        ],
+      },
+    ],
+  },
+};

--- a/example/webpack.config.headless-styling.js
+++ b/example/webpack.config.headless-styling.js
@@ -1,0 +1,19 @@
+var webpack = require('webpack');
+var hotMiddlewareScript =
+  'webpack-hot-middleware/client?path=/__webpack_hmr&timeout=20000&reload=true&overlayStyleMode=headless';
+
+module.exports = {
+  mode: 'development',
+  context: __dirname,
+  entry: {
+    client: ['./client.js', hotMiddlewareScript],
+    'headless-styling': ['./headless-styling.js', hotMiddlewareScript],
+  },
+  output: {
+    path: __dirname,
+    publicPath: '/',
+    filename: '[name].js',
+  },
+  devtool: 'source-map',
+  plugins: [new webpack.HotModuleReplacementPlugin()],
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

- Add `overlayStyleMode` option with two possible values: `inline` (default) and `headless`.
- Add `client-overlay.css` file containing the default styles.
- Fix #457.
- Update `README.md`, describe `overlayStyleMode`.
- Add examples for `csp` and `headless-styling` scenarios.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

- feat
- fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

CSP scenario:

```sh
# Reproduction for the CSP violation:
# Open /csp path, trigger an error, see the console logs.
# CSP must be violated. Styles must be blocked.
npm run start:csp::violate

# Open /csp path, trigger an error, see the console logs.
# No violation must be observed. Default styles must be applied without any issues.
npm run start:csp
```

Headless-styling scenario:

```sh
# Open /headless-styling path, trigger an error.
# `ERROR` label must be white on black, only.
npm run start:headless-styling
```

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

Documented in the [`README.md`](https://github.com/ertgl/webpack-hot-middleware/blob/046eec0d3cd5d650f34e8f8a8cc1cf6da4a7863e/README.md):

- Description of the `overlayStyleMode` option.
  - Default is `inline`.
  - Headless mode is for custom or CSP-compatible styling.
    - `webpack-hot-middleware/client-overlay.css` can be imported to enable the default styles.
    - Requires a loader to be configured for CSS files.
- `overlayStyles` option requires `overlayStyleMode` to be `inline`.

Not documented:

- [`CHANGELOG.md`](https://github.com/webpack/webpack-hot-middleware/blob/main/CHANGELOG.md)